### PR TITLE
Ensure ResponseEvaluator returns correct scores

### DIFF
--- a/src/agents/response_evaluator.py
+++ b/src/agents/response_evaluator.py
@@ -36,7 +36,10 @@ class ResponseEvaluator:
         """Return a score in [0, 1] for the supplied response."""
         text = response.lower()
         if any(re.search(pat, text) for pat in self.FAILURE_PATTERNS):
-            logger.debug("ResponseEvaluator: detected failure pattern in %s", response)
+            logger.debug(
+                "ResponseEvaluator: detected failure pattern in %s", response
+            )
             return 0.0
-        logger.debug("ResponseEvaluator: response deemed acceptable")
-        return 1.0
+        else:
+            logger.debug("ResponseEvaluator: response deemed acceptable")
+            return 1.0


### PR DESCRIPTION
## Summary
- Fix ResponseEvaluator indentation and branching so failure patterns return 0.0 while other responses return 1.0

## Testing
- `python -m pytest src/agents/tests` *(fails: file or directory not found)*
- `python -m pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68b98f65891c83229665e23b186eb087