### PR TITLE
Use pgvector pg16 image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      db:
+        image: ankane/pgvector:pg16
+        env:
+          POSTGRES_DB: warehouse
+          POSTGRES_USER: app
+          POSTGRES_PASSWORD: app_pw
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready -U app -d warehouse
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y postgresql-client
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Wait for database
+        run: |
+          for i in {1..30}; do
+            pg_isready -h localhost -U app -d warehouse && break
+            sleep 1
+          done
+      - name: Run tests
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ explicit configuration for LLMs, data sources and runtime environment.
 - **Streamlit user interface** – the front‑end is a simple Streamlit app
   (`src/ui/app.py`) that presents a chat box and conversation history.  It
   demonstrates how to integrate agents and LLMs into a modern web UI.
-- **Database integration** – a relational database (PostgreSQL by default) is
+- **Database integration** – a PostgreSQL database with the pgvector extension (via the `ankane/pgvector:pg16` image) is
   used to store and query inventory data.  A helper script
   (`scripts/init_db.py`) downloads a `.sql` dump from S3 and creates the
   database.  Database credentials and S3 details are stored in `.env`.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   db:
-    image: postgres:15
+    image: ankane/pgvector:pg16
     container_name: retail_db
     restart: unless-stopped
     environment:


### PR DESCRIPTION
## Summary
- switch Postgres image to `ankane/pgvector:pg16`
- document pgvector usage in README
- add CI workflow that starts `ankane/pgvector:pg16` service and runs tests

## Testing
- `pytest`
- `act` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b98f64a16c832287c4ffbfcd36c97d