### PR TITLE
Install PostgreSQL client in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 # Install system dependencies if needed (none here, but added for completeness)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
+    postgresql-client \
  && rm -rf /var/lib/apt/lists/*
 
 # Copy application code

--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ explicit configuration for LLMs, data sources and runtime environment.
   (`scripts/init_db.py`) downloads a `.sql` dump from S3 and creates the
   database.  Database credentials and S3 details are stored in `.env`.
 - **Dockerised deployment** – the provided `Dockerfile` and
-  `docker-compose.yaml` enable reproducible local or cloud deployments.  A
-  `run_all.sh` script demonstrates a typical end‑to‑end workflow: build
-  containers, initialise the database and launch the Streamlit UI.
+  `docker-compose.yaml` enable reproducible local or cloud deployments.  The
+  image now installs the `postgresql-client` package so database setup scripts
+  can invoke `psql`.  A `run_all.sh` script demonstrates a typical end‑to‑end
+  workflow: build containers, initialise the database and launch the Streamlit
+  UI.
 - **Testing and scripts** – skeleton unit tests under `tests/` help verify
   agent scoring and LLM integrations.  Additional scripts (`clear_out.sh`,
   etc.) are provided to tear down the environment between runs.


### PR DESCRIPTION
## Summary
- Install `postgresql-client` in the Docker image so `psql` is available for DB initialization
- Document the new system dependency in the project README

## Testing
- `pytest -q` *(fails: IndentationError in src/agents/response_evaluator.py)*
- `docker build -t warehouse-manager .` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68b98bbcc79483229aa21f6613ca6224