### PR TITLE
Remove duplicate return in BedrockLLM.generate

### DIFF
--- a/src/llm/bedrock.py
+++ b/src/llm/bedrock.py
@@ -164,8 +164,3 @@ class BedrockLLM:
         })
         logger.debug("BedrockLLM response: %s", response)
         return response
-        # The chain expects chat_history as a list of dict/tuple structures
-        return self.chain.invoke({
-            "chat_history": chat_history,
-            "user_request": user_request,
-        })


### PR DESCRIPTION
## Summary
- remove unreachable return block from BedrockLLM.generate

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b99972eff8832296406c2d7b900251