### PR TITLE
Clean up LLM manager imports and return handling

### DIFF
--- a/src/llm/manager.py
+++ b/src/llm/manager.py
@@ -13,11 +13,7 @@ import logging
 
 from .bedrock import BedrockLLM
 
-
 logger = logging.getLogger(__name__)
-
-
-from .bedrock import BedrockLLM
 
 class LLMManager:
     """Entry point for working with LLMs.
@@ -69,5 +65,4 @@ class LLMManager:
         logger.debug("LLMManager received response: %s", response)
         return response
 
-        return self.llm.generate(user_request, chat_history or [])
 


### PR DESCRIPTION
## Summary
- remove duplicate `BedrockLLM` import
- eliminate unreachable extra return in `LLMManager.generate`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b999761b1c83229899668481530524