### PR TITLE
Simplify agent manager evaluation loop

### DIFF
--- a/src/agents/agent_manager.py
+++ b/src/agents/agent_manager.py
@@ -82,16 +82,4 @@ class AgentManager:
                 return response
             last_response = response
         logger.warning("All agents failed evaluation; returning last response")
-
-        scores = [(agent, agent.score_request(user_request, chat_history)) for agent in self.agents]
-        scores.sort(key=lambda item: item[1], reverse=True)
-        last_response = ""
-        for agent, _score in scores:
-            try:
-                response = agent.handle(user_request, chat_history)
-            except Exception:
-                continue
-            if self.evaluator.evaluate(user_request, response) >= self.evaluator.threshold:
-                return response
-            last_response = response
         return last_response


### PR DESCRIPTION
## Summary
- remove redundant second evaluation loop in `AgentManager.handle_request`
- return last response after warning when all agents fail

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b99975f930832280d20740ab690588