### PR TITLE
refactor: clean product lookup agent imports and code

### DIFF
--- a/src/agents/product_lookup_agent.py
+++ b/src/agents/product_lookup_agent.py
@@ -7,20 +7,15 @@ assigns itself a low score so that other agents can take over.
 """
 from __future__ import annotations
 
+import logging
 import re
 from typing import List, Tuple
-
-import logging
 
 from .base import AgentBase
 from src.database.db_manager import get_db
 
 
 logger = logging.getLogger(__name__)
-
-from .base import AgentBase
-
-from src.database.db_manager import get_db
 
 
 class ProductLookupAgent(AgentBase):
@@ -40,13 +35,6 @@ class ProductLookupAgent(AgentBase):
         logger.debug("ProductLookupAgent score=%s for request=%s", score, user_request)
         # Normalize to [0,1]; at least 0.0 if no hits
         return score
-
-    def handle(self, user_request: str, chat_history: List[Tuple[str, str]]) -> str:
-        # Extract potential query terms by taking words longer than 3 letters
-        logger.info("ProductLookupAgent handling request")
-
-        # Normalize to [0,1]; at least 0.0 if no hits
-        return min(1.0, hits / len(self.KEYWORDS)) if hits else 0.0
 
     def handle(self, user_request: str, chat_history: List[Tuple[str, str]]) -> str:
         # Extract potential query terms by taking words longer than 3 letters
@@ -73,10 +61,3 @@ class ProductLookupAgent(AgentBase):
         result = "Here are some products I found:\n" + "\n".join(rows)
         logger.debug("Lookup result: %s", result)
         return result
-
-        df = get_db().query_df(sql)
-        if df.empty:
-            return "I'm sorry, I couldn't find any matching products."
-        # Format the DataFrame into a human readable list
-        rows = [f"{row.store}: {row.product_name} by {row.brand_name}" for _, row in df.iterrows()]
-        return "Here are some products I found:\n" + "\n".join(rows)


### PR DESCRIPTION
## Summary
- deduplicate imports in ProductLookupAgent
- remove stray handle method and redundant code

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b99978957483229a58e3989df40221