### PR TITLE
Default to Amazon Nova model

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ explicit configuration for LLMs, data sources and runtime environment.
    pip install -r requirements.txt
    ```
 
-3. **Copy the `.env.example` to `.env` and edit it** – set your AWS region,
-   Bedrock model ID, database credentials, S3 bucket and key.
+3. **Copy the `.env.example` to `.env` and edit it** – set your AWS region, database credentials, S3 bucket and key.
+   For the LLM configuration set `BEDROCK_MODEL_ID=amazon.nova-pro-v1:0`.
 
 4. **Initialise the database**
 

--- a/src/config/llm_config.yaml
+++ b/src/config/llm_config.yaml
@@ -1,6 +1,6 @@
 llm:
-  # The fully qualified Amazon Bedrock model ID.  See `.env` for examples.
-  model_id: ${BEDROCK_MODEL_ID}
+  # The fully qualified Amazon Bedrock model ID. Defaults to Amazon Nova Pro v1:0.
+  model_id: amazon.nova-pro-v1:0
   temperature: ${LLM_TEMPERATURE}
   top_p: ${LLM_TOP_P}
   max_tokens: ${LLM_MAX_TOKENS}

--- a/src/llm/bedrock.py
+++ b/src/llm/bedrock.py
@@ -35,7 +35,7 @@ class BedrockLLM:
         bed_conf = config.get("bedrock", {})
         model_id = llm_conf.get("model_id")
         if not model_id or "$" in model_id:
-            model_id = "anthropic.claude-v2:1"
+            model_id = "amazon.nova-pro-v1:0"
 
         region = bed_conf.get("region_name")
         if not region or "$" in region:


### PR DESCRIPTION
## Summary
- Default Bedrock LLM config to the Amazon Nova Pro v1:0 model and update README to set `BEDROCK_MODEL_ID=amazon.nova-pro-v1:0`.
- Fallback to Amazon Nova Pro v1:0 in Bedrock wrapper when no model_id is provided.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9997ebfa08322869997257779f402