### PR TITLE
Load SQL dump during run_all startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,11 @@ explicit configuration for LLMs, data sources and runtime environment.
   (`src/ui/app.py`) that presents a chat box and conversation history.  It
   demonstrates how to integrate agents and LLMs into a modern web UI.
 - **Database integration** – a PostgreSQL database with the pgvector extension (via the `ankane/pgvector` image) is
-  used to store and query inventory data.  A helper script
-  (`scripts/init_db.py`) downloads a `.sql` dump from S3 and creates the
-  database.  Database credentials and S3 details are stored in `.env`.
+  used to store and query inventory data.  The `run_all.sh` helper script
+  downloads the `.sql` dump from S3, imports it into the database, verifies the
+  expected tables exist and then launches the app; `scripts/init_db.py` simply
+  verifies the database and required extensions.  Database credentials and S3
+  details are stored in `.env`.
 - **Dockerised deployment** – the provided `Dockerfile` and
   `docker-compose.yaml` enable reproducible local or cloud deployments.  The
   image now installs the `postgresql-client` package so database setup scripts
@@ -58,6 +60,9 @@ explicit configuration for LLMs, data sources and runtime environment.
    For the LLM configuration set `BEDROCK_MODEL_ID=amazon.nova-pro-v1:0`.
 
 4. **Initialise the database**
+
+   Import the inventory SQL dump first (the provided `run_all.sh` script does
+   this automatically before launching the app) or load it manually, then run:
 
    ```sh
    python scripts/init_db.py

--- a/run_all.sh
+++ b/run_all.sh
@@ -26,8 +26,26 @@ if [[ -n "${S3_BUCKET:-}" && -n "${S3_KEY:-}" ]]; then
   unset S3_BUCKET S3_KEY S3_PRESIGNED_URL
 fi
 
-echo "Building Docker images and starting services…"
+echo "Building Docker images…"
 docker-compose build
-docker-compose up -d
+
+echo "Starting database…"
+docker-compose up -d db
+
+if [ -n "${SQL_FILE:-}" ]; then
+  echo "Waiting for database to become ready…"
+  until docker-compose exec -T db pg_isready -U "${DB_USER:-app}" -d "${DB_NAME:-warehouse}" >/dev/null 2>&1; do
+    sleep 1
+  done
+
+  echo "Importing SQL dump into database…"
+  docker-compose exec -T db psql -v ON_ERROR_STOP=1 -U "${DB_USER:-app}" -d "${DB_NAME:-warehouse}" < "$SQL_FILE"
+
+  echo "Verifying imported tables…"
+  docker-compose exec -T db psql -U "${DB_USER:-app}" -d "${DB_NAME:-warehouse}" -c "SELECT COUNT(*) FROM vip_products LIMIT 1" >/dev/null
+fi
+
+echo "Starting application…"
+docker-compose up -d app
 
 echo "Services are up.  Database initialisation and embedding indexing run inside the container."

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -1,17 +1,12 @@
-"""Initialise the application database.
+"""Verify the application database.
 
-This script creates the core tables required by the app and loads seed data
-from the SQL dump supplied with the liquor and wine inventory.  The dump must
-be sourced from S3 – either streamed directly using ``S3_BUCKET`` and
-``S3_KEY`` or by providing the path to a local copy via ``SQL_FILE``.  If no
-SQL source is provided the script will fail rather than creating placeholder
-tables.
+The inventory SQL dump is imported before the app starts (see ``run_all.sh``).
+This script only ensures required extensions exist and expected tables are
+present; it does **not** create or load any data.
 """
 from __future__ import annotations
 
-import os
 import sys
-import subprocess
 from pathlib import Path
 
 import logging
@@ -25,96 +20,18 @@ if str(SRC) not in sys.path:
 from config.logging_config import setup_logging  # noqa: E402
 from database.db_manager import get_db  # noqa: E402  (import after path tweak)
 
-from sqlalchemy import create_engine  # noqa: E402
-try:  # Optional dependency for pgvector
-    from pgvector.sqlalchemy import register_vector  # type: ignore  # noqa: E402
-except Exception:  # pragma: no cover - optional dependency
-    register_vector = None  # type: ignore
-
 
 logger = logging.getLogger(__name__)
-
-def _load_sql() -> str:
-    """Load SQL statements from S3 or a local file copied from S3."""
-    bucket = os.getenv("S3_BUCKET")
-    key = os.getenv("S3_KEY")
-    local_path = os.getenv("SQL_FILE")
-
-    if bucket and key:
-        logger.info("Loading SQL from S3 bucket=%s key=%s", bucket, key)
-        try:
-            s3_uri = f"s3://{bucket}/{key}"
-            result = subprocess.run(
-                ["aws", "s3", "cp", s3_uri, "-"],
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-            return result.stdout
-        except Exception as exc:
-            logger.exception("Failed to load SQL from S3: %s", exc)
-            raise
-
-    if local_path and os.path.exists(local_path):
-        logger.info("Loading SQL from local file %s", local_path)
-        try:
-            with open(local_path, "r", encoding="utf-8") as f:
-                return f.read()
-        except Exception as exc:
-            logger.exception("Failed to read SQL file %s: %s", local_path, exc)
-            raise
-
-    raise FileNotFoundError(
-        "No SQL source provided; set S3_BUCKET/S3_KEY or SQL_FILE to the dump from S3"
-    )
-
-
-def _execute_sql(sql: str, db_url: str) -> None:
-    """Execute a SQL script against ``db_url``.
-
-    The function prefers the ``psql`` command line client for maximum
-    compatibility with dumps produced by ``pg_dump``.  If ``psql`` is not
-    available (for example when running in a minimal test environment) it
-    falls back to using SQLAlchemy directly so that at least basic
-    statements can be executed.  Any errors from ``psql`` are surfaced to the
-    caller so that the initialisation can fail fast.
-    """
-    try:
-        subprocess.run(
-            ["psql", db_url, "-v", "ON_ERROR_STOP=1"],
-            input=sql,
-            text=True,
-            check=True,
-            capture_output=True,
-        )
-        return
-    except FileNotFoundError:
-        logger.warning("psql not found – falling back to SQLAlchemy execution")
-    except subprocess.CalledProcessError as exc:
-        logger.error("psql failed: %s", exc.stderr.strip())
-        raise
-
-    # Fallback using SQLAlchemy; this is a best-effort approach and will not
-    # handle every ``pg_dump`` feature but allows unit tests or simple setups
-    # without ``psql`` to execute standard SQL statements.
-    engine = create_engine(db_url, future=True)
-    if register_vector:
-        register_vector(engine)
-    try:
-        with engine.begin() as conn:
-            conn.exec_driver_sql(sql)
-    finally:
-        engine.dispose()
 
 def main() -> None:
     setup_logging()
     logger.info("Starting database initialisation")
     try:
         db = get_db()
-        sql = _load_sql()
-        _execute_sql(sql, db.url)
-        db.execute("CREATE EXTENSION IF NOT EXISTS vector")
-        # Verify that core tables from the dump are present
+        try:
+            db.execute("CREATE EXTENSION IF NOT EXISTS vector")
+        except Exception as exc:  # pragma: no cover - depends on DB
+            logger.warning("Vector extension unavailable: %s", exc)
         db.query_df("SELECT 1 FROM vip_products LIMIT 1")
     except Exception:
         logger.exception("Database initialisation failed")


### PR DESCRIPTION
## Summary
- import downloaded inventory dump into PostgreSQL before starting the app and confirm `vip_products` exists
- document the automated import and verification workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb3714077c8322a753e384e99b80ba