### PR TITLE
fix: remove compose version and ensure db restart readiness

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   db:
     # Explicitly pin to the latest pgvector image; the pg16 tag does not exist

--- a/run_all.sh
+++ b/run_all.sh
@@ -41,6 +41,11 @@ if [ -n "${SQL_FILE:-}" ]; then
   echo "Importing SQL dump into database…"
   docker-compose exec -T db psql -v ON_ERROR_STOP=1 -U "${DB_USER:-app}" -d "${DB_NAME:-warehouse}" < "$SQL_FILE"
 
+  echo "Waiting for database to restart after import…"
+  until docker-compose exec -T db pg_isready -U "${DB_USER:-app}" -d "${DB_NAME:-warehouse}" >/dev/null 2>&1; do
+    sleep 1
+  done
+
   echo "Verifying imported tables…"
   docker-compose exec -T db psql -U "${DB_USER:-app}" -d "${DB_NAME:-warehouse}" -c "SELECT COUNT(*) FROM vip_products LIMIT 1" >/dev/null
 fi


### PR DESCRIPTION
## Summary
- remove obsolete `version` key from docker-compose
- wait for the database to restart after SQL import in `run_all.sh`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68beb285f334832286a785d5e57f8b5c