### PR TITLE
fix: remove compose version and ensure db restart readiness

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   db:
     # Explicitly pin to the latest pgvector image; the pg16 tag does not exist


### PR DESCRIPTION
## Summary
- remove obsolete `version` key from docker-compose
- wait for the database to restart after SQL import in `run_all.sh`
- strip unsupported `transaction_timeout` setting from SQL dump before import

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68beb285f334832286a785d5e57f8b5c