### PR TITLE
feat: run DuckDB-only workflows and disable LLM features

### DIFF
--- a/run_all.sh
+++ b/run_all.sh
@@ -12,29 +12,36 @@ if [ -f .env ]; then
   export $(grep -v '^#' .env | xargs)
 fi
 
+: "${ENABLE_LLM:=0}"
+export ENABLE_LLM
+
 log() { echo -e "\n\033[1;32m[run_all]\033[0m $*"; }
 die() { echo "❌ $*" >&2; exit 1; }
 
 # Required env (your set)
-: "${BEDROCK_MODEL_ID:?missing}"
-: "${LLM_TEMPERATURE:?missing}"
-: "${LLM_TOP_P:?missing}"
-: "${LLM_MAX_TOKENS:?missing}"
-
-: "${S3_BUCKET:?missing}"
-: "${S3_KEY:?missing}"
-
-: "${DB_HOST:=localhost}"
-: "${DB_PORT:=5432}"
-: "${DB_NAME:?missing}"
-: "${DB_USER:?missing}"
-: "${DB_PASS:?missing}"
-: "${DATABASE_URL:=postgresql://${DB_USER}:${DB_PASS}@${DB_HOST}:${DB_PORT}/${DB_NAME}}"
+case "${ENABLE_LLM:-}" in
+  1|true|TRUE|True|yes|YES|Yes|on|ON|On)
+    : "${BEDROCK_MODEL_ID:?missing}"
+    : "${LLM_TEMPERATURE:?missing}"
+    : "${LLM_TOP_P:?missing}"
+    : "${LLM_MAX_TOKENS:?missing}"
+    ;;
+  *)
+    log "ENABLE_LLM not set – skipping Bedrock environment checks"
+    ;;
+esac
 
 APP_DIR="/opt/WarehouseManagerAI"
-VIEWS_SQL="${APP_DIR}/views/999_app_views.sql"
+
+# DuckDB paths used across the app.  The SQL dump mirrors the structure of the
+# legacy PostgreSQL database so DuckDB can be refreshed from the same data.
+DUCKDB_DB_PATH="${DUCKDB_DB_PATH:-$APP_DIR/data/postgres_mirror.duckdb}"
 DUCKDB_SQL_DUMP="${DUCKDB_SQL_DUMP:-$APP_DIR/data/postgres_dump.sql}"
+mkdir -p "$(dirname "$DUCKDB_DB_PATH")"
 mkdir -p "$(dirname "$DUCKDB_SQL_DUMP")"
+
+export DUCKDB_FALLBACK_PATH="$DUCKDB_DB_PATH"
+export DUCKDB_SQL_DUMP
 
 # Pick compose command
 if command -v docker-compose >/dev/null 2>&1; then
@@ -43,26 +50,29 @@ else
   DC="docker compose"
 fi
 
-# Free port 5432 in case host PG is running
-sudo systemctl stop postgresql >/dev/null 2>&1 || true
-sudo fuser -k 5432/tcp >/dev/null 2>&1 || true
-
-log "Starting Postgres (pgvector) via Docker Compose…"
-$DC up -d db || true
-
-STATUS=$(docker inspect -f '{{.State.Status}}' warehousemanagerai_db 2>/dev/null || echo "not-found")
-if [ "$STATUS" != "running" ]; then
-  log "Container status: $STATUS. Resetting volume and retrying…"
-  $DC down
-  docker volume rm warehousemanagerai_db_data >/dev/null 2>&1 || true
-  $DC up -d db
-fi
-
-log "Waiting for Postgres to be ready…"
-until docker exec warehousemanagerai_db pg_isready -U "$DB_USER" -d "$DB_NAME" >/dev/null 2>&1; do
-  sleep 1
-done
-log "Postgres is ready on ${DB_HOST}:${DB_PORT}"
+# Legacy PostgreSQL orchestration is temporarily disabled while running in a
+# DuckDB-only configuration.  The Docker compose stack is left untouched so it
+# can be re-enabled later if required.
+#
+# sudo systemctl stop postgresql >/dev/null 2>&1 || true
+# sudo fuser -k 5432/tcp >/dev/null 2>&1 || true
+#
+# log "Starting Postgres (pgvector) via Docker Compose…"
+# $DC up -d db || true
+#
+# STATUS=$(docker inspect -f '{{.State.Status}}' warehousemanagerai_db 2>/dev/null || echo "not-found")
+# if [ "$STATUS" != "running" ]; then
+#   log "Container status: $STATUS. Resetting volume and retrying…"
+#   $DC down
+#   docker volume rm warehousemanagerai_db_data >/dev/null 2>&1 || true
+#   $DC up -d db
+# fi
+#
+# log "Waiting for Postgres to be ready…"
+# until docker exec warehousemanagerai_db pg_isready -U "$DB_USER" -d "$DB_NAME" >/dev/null 2>&1; do
+#   sleep 1
+# done
+# log "Postgres is ready on ${DB_HOST}:${DB_PORT}"
 
 # Helper: stream filter to drop problematic role lines (NO temp files)
 stream_filter() {
@@ -74,124 +84,195 @@ stream_filter() {
     -e '/ALTER\s+.*\s+OWNER\s+TO\s+[^;]+;/I d'
 }
 
-# Check for existing data
-log "Checking for existing data (vip_products)…"
-TABLE_EXISTS=$(
-  docker exec -e PGPASSWORD="$DB_PASS" warehousemanagerai_db \
-    psql -U "$DB_USER" -d "$DB_NAME" -tAc "SELECT to_regclass('public.vip_products');" || true
-)
+# DuckDB-only data loading ----------------------------------------------------
 
-if [ "$TABLE_EXISTS" = "vip_products" ]; then
-  log "Data already present; skipping import."
-  docker exec -e PGPASSWORD="$DB_PASS" warehousemanagerai_db \
-    psql -U "$DB_USER" -d "$DB_NAME" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION IF NOT EXISTS vector;"
+if [ -n "${SQL_FILE:-}" ] && [ -f "$SQL_FILE" ]; then
+  log "Importing from local file: $SQL_FILE (sanitized grants/owners)"
+  stream_filter < "$SQL_FILE" > "$DUCKDB_SQL_DUMP"
+elif [ -n "${S3_PRESIGNED_URL:-}" ]; then
+  log "Importing from presigned URL (sanitized grants/owners)…"
+  curl -sSL "$S3_PRESIGNED_URL" | stream_filter > "$DUCKDB_SQL_DUMP"
 else
-  log "No data found; preparing schema + extension…"
-  docker exec -e PGPASSWORD="$DB_PASS" warehousemanagerai_db \
-    psql -U "$DB_USER" -d "$DB_NAME" -v ON_ERROR_STOP=1 -c "DROP SCHEMA IF EXISTS public CASCADE; CREATE SCHEMA public AUTHORIZATION ${DB_USER};"
-  docker exec -e PGPASSWORD="$DB_PASS" warehousemanagerai_db \
-    psql -U "$DB_USER" -d "$DB_NAME" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION IF NOT EXISTS vector;"
-
-  if [ -n "${SQL_FILE:-}" ] && [ -f "$SQL_FILE" ]; then
-    log "Importing from local file: $SQL_FILE (sanitized grants/owners)"
-    stream_filter < "$SQL_FILE" > "$DUCKDB_SQL_DUMP"
-  elif [ -n "${S3_PRESIGNED_URL:-}" ]; then
-    log "Importing from presigned URL (sanitized grants/owners)…"
-    curl -sSL "$S3_PRESIGNED_URL" | stream_filter > "$DUCKDB_SQL_DUMP"
-  else
-    log "Importing from s3://$S3_BUCKET/$S3_KEY (sanitized grants/owners)…"
-    aws s3 cp "s3://${S3_BUCKET}/${S3_KEY}" - | stream_filter > "$DUCKDB_SQL_DUMP"
-  fi
-  log "Sanitized SQL dump written to $DUCKDB_SQL_DUMP for DuckDB fallback."
-  cat "$DUCKDB_SQL_DUMP" | docker exec -i -e PGPASSWORD="$DB_PASS" warehousemanagerai_db \
-    psql -U "$DB_USER" -d "$DB_NAME" -v ON_ERROR_STOP=1
-  log "Import complete."
-
-  # Post-import: normalize ownership & permissions for app user
-  log "Normalizing ownership to ${DB_USER} and granting read permissions…"
-  docker exec -e PGPASSWORD="$DB_PASS" warehousemanagerai_db psql -U "$DB_USER" -d "$DB_NAME" -v ON_ERROR_STOP=1 <<PSQL
--- Make sure public schema belongs to app
-ALTER SCHEMA public OWNER TO "${DB_USER}";
-
--- Reassign owners of tables, sequences, views, materialized views
-DO \$\$
-DECLARE r RECORD;
-BEGIN
-  -- Tables
-  FOR r IN SELECT quote_ident(schemaname) AS s, quote_ident(tablename) AS n
-           FROM pg_tables WHERE schemaname='public' LOOP
-    EXECUTE 'ALTER TABLE ' || r.s || '.' || r.n || ' OWNER TO "${DB_USER}"';
-  END LOOP;
-
-  -- Sequences
-  FOR r IN SELECT quote_ident(sequence_schema) AS s, quote_ident(sequence_name) AS n
-           FROM information_schema.sequences WHERE sequence_schema='public' LOOP
-    EXECUTE 'ALTER SEQUENCE ' || r.s || '.' || r.n || ' OWNER TO "${DB_USER}"';
-  END LOOP;
-
-  -- Views
-  FOR r IN SELECT quote_ident(schemaname) AS s, quote_ident(viewname) AS n
-           FROM pg_views WHERE schemaname='public' LOOP
-    EXECUTE 'ALTER VIEW ' || r.s || '.' || r.n || ' OWNER TO "${DB_USER}"';
-  END LOOP;
-
-  -- Materialized views
-  FOR r IN SELECT quote_ident(schemaname) AS s, quote_ident(matviewname) AS n
-           FROM pg_matviews WHERE schemaname='public' LOOP
-    EXECUTE 'ALTER MATERIALIZED VIEW ' || r.s || '.' || r.n || ' OWNER TO "${DB_USER}"';
-  END LOOP;
-END
-\$\$;
-
--- Default privileges for future objects in public: readable by PUBLIC
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO PUBLIC;
-
--- Grant read on existing tables to PUBLIC (so any connector you use can read)
-GRANT USAGE ON SCHEMA public TO PUBLIC;
-GRANT SELECT ON ALL TABLES IN SCHEMA public TO PUBLIC;
-PSQL
+  : "${S3_BUCKET:?missing}"
+  : "${S3_KEY:?missing}"
+  log "Importing from s3://$S3_BUCKET/$S3_KEY (sanitized grants/owners)…"
+  aws s3 cp "s3://${S3_BUCKET}/${S3_KEY}" - | stream_filter > "$DUCKDB_SQL_DUMP"
 fi
+log "Sanitized SQL dump written to $DUCKDB_SQL_DUMP for DuckDB refresh."
 
-# Apply view if missing
-if [ ! -f "$VIEWS_SQL" ]; then
-  die "Missing $VIEWS_SQL"
-fi
-VIEW_EXISTS=$(
-  docker exec -e PGPASSWORD="$DB_PASS" warehousemanagerai_db \
-    psql -U "$DB_USER" -d "$DB_NAME" -tAc "SELECT to_regclass('public.app_inventory');" || true
+log "Building DuckDB database at $DUCKDB_DB_PATH"
+python3 <<'PY'
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path.cwd()
+if str(ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(ROOT / "src"))
+
+from src.database.db_manager import DBManager
+
+dump = os.environ["DUCKDB_SQL_DUMP"]
+db_path = os.environ["DUCKDB_FALLBACK_PATH"]
+
+manager = DBManager(
+    enable_duckdb_fallback=True,
+    duckdb_path=db_path,
+    duckdb_auto_sync=False,
+    duckdb_sql_dump_path=dump,
 )
-if [ "$VIEW_EXISTS" = "app_inventory" ]; then
-  log "View app_inventory already exists; skipping SQL apply."
-else
-  log "Applying ${VIEWS_SQL} …"
-  docker exec -i -e PGPASSWORD="$DB_PASS" warehousemanagerai_db \
-    psql -U "$DB_USER" -d "$DB_NAME" -v ON_ERROR_STOP=1 < "$VIEWS_SQL"
-  log "Views applied."
+try:
+    manager.sync_duckdb_backup()
+finally:
+    manager.close()
+PY
+
+if [ ! -f "$DUCKDB_DB_PATH" ]; then
+  die "DuckDB database was not created at $DUCKDB_DB_PATH"
 fi
 
-# Export DB URL for app
-export DATABASE_URL="postgresql://${DB_USER}:${DB_PASS}@${DB_HOST}:${DB_PORT}/${DB_NAME}"
-export DUCKDB_SQL_DUMP
+# Apply view definitions directly in DuckDB
+log "Generating app_inventory view for DuckDB…"
+python3 <<'PY'
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path.cwd()
+if str(ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(ROOT / "src"))
+
+from src.database.db_manager import DBManager
+
+manager = DBManager(
+    enable_duckdb_fallback=True,
+    duckdb_auto_sync=False,
+)
+try:
+    columns_df = manager.query_df(
+        """
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'vip_items'
+        """,
+        None,
+    )
+    col_names = {name.lower() for name in columns_df["column_name"].tolist()}
+    has_store = "store" in col_names
+    has_source_id = "vip_source_id" in col_names
+
+    select_parts = ["i.*"]
+    if not has_store:
+        if has_source_id:
+            select_parts.append("('source_' || CAST(i.vip_source_id AS VARCHAR)) AS store")
+        else:
+            select_parts.append("CAST(NULL AS VARCHAR) AS store")
+
+    product_expr = """
+            COALESCE(NULLIF(TRIM(p.consumer_product_name), ''),
+                     NULLIF(TRIM(p.product_name), ''),
+                     NULLIF(TRIM(p.product_short_name), ''),
+                     NULLIF(TRIM(p.fanciful_name), ''),
+                     'Unknown') AS product_name
+        """.strip()
+
+    brand_expr = """
+            COALESCE(NULLIF(TRIM(b.consumer_brand_name), ''),
+                     NULLIF(TRIM(b.brand_name), ''),
+                     NULLIF(TRIM(b.brand_short_name), ''),
+                     'Unknown') AS brand_name
+        """.strip()
+
+    select_parts.extend([product_expr, brand_expr])
+
+    select_clause = ",\n        ".join(select_parts)
+    manager.execute("DROP VIEW IF EXISTS app_inventory")
+    manager.execute(
+        f"""
+        CREATE VIEW app_inventory AS
+        SELECT
+        {select_clause}
+        FROM vip_items i
+        JOIN vip_products p ON p.vip_product_id = i.vip_product_id
+        JOIN vip_brands b ON b.vip_brand_id = p.vip_brand_id
+        """
+    )
+finally:
+    manager.close()
+PY
+
+# Export DB URL for app (duckdb:// URI)
+export DATABASE_URL="duckdb:///${DUCKDB_DB_PATH}"
 log "DATABASE_URL set to: ${DATABASE_URL}"
 
-# Verify
-log "Verifying app_inventory…"
-docker exec -e PGPASSWORD="$DB_PASS" warehousemanagerai_db \
-  psql -U "$DB_USER" -d "$DB_NAME" -c "SELECT COUNT(*) AS total_items FROM app_inventory;" || true
-docker exec -e PGPASSWORD="$DB_PASS" warehousemanagerai_db \
-  psql -U "$DB_USER" -d "$DB_NAME" -c "SELECT store, product_name, brand_name FROM app_inventory LIMIT 5;" || true
+log "Verifying app_inventory via DuckDB…"
+python3 <<'PY'
+import os
+import sys
+from pathlib import Path
 
-log "✅ Postgres in Docker is ready, with grants/owners stripped (no extra roles needed)."
+ROOT = Path.cwd()
+if str(ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(ROOT / "src"))
 
-log "Exporting database schema to src/database/schema.json"
-docker exec -e PGPASSWORD="$DB_PASS" warehousemanagerai_db \
-  psql -U "$DB_USER" -d "$DB_NAME" -t -c \
-  "SELECT jsonb_pretty(jsonb_object_agg(table_name, columns)) FROM \
-   (SELECT table_name, jsonb_agg(column_name ORDER BY ordinal_position) AS columns \
-    FROM information_schema.columns \
-    WHERE table_schema='public' \
-    GROUP BY table_name) AS schema_json;" \
-  > src/database/schema.json
+from src.database.db_manager import DBManager
+
+manager = DBManager(
+    enable_duckdb_fallback=True,
+    duckdb_auto_sync=False,
+)
+try:
+    df = manager.query_df("SELECT COUNT(*) AS total_items FROM app_inventory", None)
+    print(df.to_string(index=False))
+    preview = manager.query_df(
+        "SELECT store, product_name, brand_name FROM app_inventory LIMIT 5",
+        None,
+    )
+    print(preview.to_string(index=False))
+finally:
+    manager.close()
+PY
+
+log "Exporting database schema to src/database/schema.json using DuckDB"
+python3 <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path.cwd()
+if str(ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(ROOT / "src"))
+
+from src.database.db_manager import DBManager
+
+schema_path = Path("src/database/schema.json")
+manager = DBManager(
+    enable_duckdb_fallback=True,
+    duckdb_auto_sync=False,
+)
+try:
+    df = manager.query_df(
+        """
+        SELECT table_name, column_name
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+        ORDER BY table_name, ordinal_position
+        """,
+        None,
+    )
+finally:
+    manager.close()
+
+schema = {}
+for table, column in zip(df["table_name"], df["column_name"]):
+    schema.setdefault(table, []).append(column)
+
+schema_path.parent.mkdir(parents=True, exist_ok=True)
+schema_path.write_text(json.dumps(schema, indent=2), encoding="utf-8")
+PY
+
+log "✅ DuckDB is ready with sanitized data."
 
 
 

--- a/scripts/index_embeddings.py
+++ b/scripts/index_embeddings.py
@@ -1,10 +1,12 @@
 """Populate embeddings for products imported from the S3 inventory dump."""
 from __future__ import annotations
 
+import json
+import os
 import sys
 from pathlib import Path
 
-from sqlalchemy import text
+# from sqlalchemy import text
 
 # Ensure ``src`` is importable when this script is executed directly
 ROOT = Path(__file__).resolve().parents[1]
@@ -13,7 +15,14 @@ if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
 from database.db_manager import get_db
-from llm.embeddings import EmbeddingManager
+
+try:  # Embedding generation is optional while the LLM is disabled
+    from llm.embeddings import EmbeddingManager  # type: ignore
+except Exception as exc:  # pragma: no cover - optional dependency guard
+    EmbeddingManager = None  # type: ignore
+    _EMBEDDINGS_IMPORT_ERROR = exc
+else:  # pragma: no cover
+    _EMBEDDINGS_IMPORT_ERROR = None
 
 try:  # optional pgvector adapter
     from pgvector.sqlalchemy import register_vector  # type: ignore
@@ -21,10 +30,30 @@ except Exception:  # pragma: no cover - optional dependency
     register_vector = None  # type: ignore
 
 
+def _env_flag(name: str, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    value = value.strip().lower()
+    if value in {"1", "true", "yes", "on"}:
+        return True
+    if value in {"0", "false", "no", "off"}:
+        return False
+    return default
+
+
 def main() -> None:
+    if not _env_flag("ENABLE_LLM", False) or EmbeddingManager is None:
+        if EmbeddingManager is None and _EMBEDDINGS_IMPORT_ERROR is not None:
+            print(
+                f"Skipping embedding indexing – dependencies unavailable: {_EMBEDDINGS_IMPORT_ERROR}"
+            )
+        else:
+            print("Skipping embedding indexing because LLM is disabled")
+        return
     db = get_db()
-    if register_vector:
-        register_vector(db.engine)
+    # if register_vector:
+    #     register_vector(db.engine)
     embedder = EmbeddingManager()
     df = db.query_df(
         """
@@ -42,16 +71,13 @@ def main() -> None:
         for _, row in df.iterrows()
     ]
     vectors = embedder.embed_documents(texts)
-    update = text(
-        """
+    update_sql = """
         UPDATE vip_products
         SET embedding = :embedding
         WHERE id = :id
-        """
-    )
-    with db.engine.begin() as conn:
-        for row, vec in zip(df.itertuples(), vectors):
-            conn.execute(update, {"id": row.id, "embedding": vec})
+    """
+    for row, vec in zip(df.itertuples(), vectors):
+        db.execute(update_sql, {"id": row.id, "embedding": json.dumps(list(vec))})
     print(f"Indexed {len(vectors)} product embeddings")
 
 

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -29,15 +29,18 @@ def main() -> None:
     logger.info("Starting database initialisation")
     try:
         db = get_db()
-        try:
-            db.execute("CREATE EXTENSION IF NOT EXISTS vector")
-        except Exception as exc:  # pragma: no cover - depends on DB
-            logger.warning("Vector extension unavailable: %s", exc)
-        try:
-            db.execute("ALTER TABLE vip_products ADD COLUMN IF NOT EXISTS embedding VECTOR(1536)")
-            logger.info("Ensured vip_products.embedding VECTOR(1536).")
-        except Exception as exc:
-            logger.warning("Could not ensure embedding column (continuing): %s", exc)
+        logger.info("PostgreSQL extension checks skipped; running in DuckDB-only mode.")
+        # try:
+        #     db.execute("CREATE EXTENSION IF NOT EXISTS vector")
+        # except Exception as exc:  # pragma: no cover - depends on DB
+        #     logger.warning("Vector extension unavailable: %s", exc)
+        # try:
+        #     db.execute(
+        #         "ALTER TABLE vip_products ADD COLUMN IF NOT EXISTS embedding VECTOR(1536)"
+        #     )
+        #     logger.info("Ensured vip_products.embedding VECTOR(1536).")
+        # except Exception as exc:
+        #     logger.warning("Could not ensure embedding column (continuing): %s", exc)
         db.query_df("SELECT 1 FROM vip_products LIMIT 1")
     except Exception:
         logger.exception("Database initialisation failed")

--- a/src/agents/agent_manager.py
+++ b/src/agents/agent_manager.py
@@ -36,12 +36,21 @@ class AgentManager:
             Scorer used to judge whether an agent's response is satisfactory.
         """
         self.llm_manager = llm_manager
-        self.agents: List[AgentBase] = agents or [
-            VectorSearchAgent(llm_manager),
-            ProductLookupAgent(),
-            SqlQueryAgent(llm_manager),
-            GeneralChatAgent(llm_manager)
-        ]
+        if agents is not None:
+            self.agents = list(agents)
+        else:
+            if self.llm_manager.is_enabled():
+                self.agents = [
+                    VectorSearchAgent(llm_manager),
+                    ProductLookupAgent(),
+                    SqlQueryAgent(llm_manager),
+                    GeneralChatAgent(llm_manager),
+                ]
+            else:
+                logger.info(
+                    "LLM disabled – defaulting to ProductLookupAgent only"
+                )
+                self.agents = [ProductLookupAgent()]
         self.evaluator = evaluator or ResponseEvaluator()
         logger.debug(
             "AgentManager initialised with agents=%s evaluator_threshold=%s",

--- a/src/agents/general_chat_agent.py
+++ b/src/agents/general_chat_agent.py
@@ -26,6 +26,8 @@ class GeneralChatAgent(AgentBase):
         logger.debug("GeneralChatAgent scoring request: %s", user_request)
 
         # Always return a baseline score.  This agent is a catch‑all.
+        if not self.llm_manager.is_enabled():
+            return 0.0
         return 0.5
 
     def handle(self, user_request: str, chat_history: List[Tuple[str, str]]) -> str:
@@ -39,6 +41,11 @@ class GeneralChatAgent(AgentBase):
         message so the user understands why no answer was produced.
         """
         logger.info("GeneralChatAgent handling request")
+        if not self.llm_manager.is_enabled():
+            return (
+                "The language model is disabled while running in DuckDB-only mode. "
+                "Enable the LLM to restore free-form conversations."
+            )
         try:
             response = self.llm_manager.generate(user_request, chat_history)
             logger.debug("LLM response: %s", response)

--- a/src/agents/vector_search_agent.py
+++ b/src/agents/vector_search_agent.py
@@ -1,9 +1,10 @@
 import logging
-from typing import Optional, List, Dict, Tuple
+from typing import List, Tuple
 from .base import AgentBase
 from src.llm.manager import LLMManager
 from src.database.db_manager import get_db
-from sqlalchemy import event
+
+# from sqlalchemy import event
 
 logger = logging.getLogger(__name__)
 
@@ -11,7 +12,7 @@ try:
     from pgvector.psycopg2 import register_vector
 except ImportError:
     register_vector = None
-    logger.warning("pgvector module not available; vector search disabled.")
+    logger.info("pgvector module not available; continuing with DuckDB-only mode.")
 
 class VectorSearchAgent(AgentBase):
     """
@@ -21,17 +22,21 @@ class VectorSearchAgent(AgentBase):
 
     def __init__(self, llm_manager: LLMManager) -> None:
         self.llm_manager = llm_manager
-        # Initialize DB connection and ensure pgvector is registered on connect
+        # Initialize DB connection; pgvector registration is skipped while using DuckDB only
         self.db = get_db()
-        try:
-            engine = self.db.engine
-        except AttributeError:
-            engine = getattr(self.db, "_db").engine
-        if register_vector is not None:
-            event.listen(engine, "connect", lambda conn, rec: register_vector(conn))
-            logger.debug("VectorSearchAgent initialized with pgvector adapter registered.")
-        else:
-            logger.warning("pgvector adapter not registered, vector search disabled.")
+        self._enabled = self.llm_manager.is_enabled()
+        if not self._enabled:
+            logger.info(
+                "VectorSearchAgent initialised with LLM disabled; queries will return a placeholder"
+            )
+        # try:
+        #     engine = self.db.engine
+        # except AttributeError:
+        #     engine = getattr(self.db, "_db").engine
+        # if register_vector is not None:
+        #     event.listen(engine, "connect", lambda conn, rec: register_vector(conn))
+        #     logger.debug("VectorSearchAgent initialized with pgvector adapter registered.")
+        logger.info("VectorSearchAgent running with DuckDB backend; pgvector registration disabled.")
 
     def score_request(self, user_request: str, chat_history: List[Tuple[str, str]]) -> float:
         """
@@ -39,6 +44,8 @@ class VectorSearchAgent(AgentBase):
         contains product/brand keywords (to let the ProductLookupAgent handle them).
         Otherwise return a baseline score.
         """
+        if not self._enabled:
+            return 0.0
         text = (user_request or "").lower()
         from .product_lookup_agent import ProductLookupAgent
         if any(keyword in text for keyword in ProductLookupAgent._KEYWORDS):
@@ -51,6 +58,11 @@ class VectorSearchAgent(AgentBase):
         """
         Compute the query embedding and perform a pgvector similarity search in vip_products.
         """
+        if not self._enabled:
+            return (
+                "Vector search is disabled while the language model is offline. "
+                "Enable the LLM to restore semantic lookups."
+            )
         text = (user_request or "").strip()
         if not text:
             return "What product or feature are you interested in?"

--- a/src/config/database_config.yaml
+++ b/src/config/database_config.yaml
@@ -1,10 +1,11 @@
 database:
-  driver: postgresql
-  host: ${DB_HOST}
-  port: ${DB_PORT}
-  database: ${DB_NAME}
-  username: ${DB_USER}
-  password: ${DB_PASS}
-  # If provided, SQLAlchemy will use this URL directly; otherwise it is
-  # constructed from the host/user/password values.
-  sqlalchemy_url: ${DATABASE_URL}
+  driver: duckdb
+  path: ${DUCKDB_FALLBACK_PATH}
+  sql_dump: ${DUCKDB_SQL_DUMP}
+  # Legacy PostgreSQL settings retained for reference during DuckDB-only mode:
+  # host: ${DB_HOST}
+  # port: ${DB_PORT}
+  # database: ${DB_NAME}
+  # username: ${DB_USER}
+  # password: ${DB_PASS}
+  # sqlalchemy_url: ${DATABASE_URL}

--- a/src/database/db_manager.py
+++ b/src/database/db_manager.py
@@ -480,6 +480,26 @@ class DuckDBMirror:
             conn.close()
         return result
 
+    def execute(self, sql: str, params: Optional[Mapping[str, Any]] = None) -> None:
+        if not self.available:
+            raise RuntimeError("DuckDB fallback is not available")
+
+        import duckdb
+
+        rendered_sql, values = self._render_sql(sql, params)
+        os.makedirs(os.path.dirname(self.path) or ".", exist_ok=True)
+        conn = duckdb.connect(self.path)
+        try:
+            conn.execute("CREATE SCHEMA IF NOT EXISTS public;")
+            conn.execute("SET schema 'public'")
+            if values:
+                conn.execute(rendered_sql, values)
+            else:
+                conn.execute(rendered_sql)
+            conn.execute("CHECKPOINT;")
+        finally:
+            conn.close()
+
     def vector_similarity(
         self, query_vector: Sequence[float], *, limit: int = 5
     ) -> pd.DataFrame:
@@ -563,16 +583,19 @@ class DBManager:
         duckdb_sync_interval: Optional[float] = None,
         duckdb_sql_dump_path: Optional[str] = None,
     ) -> None:
-        self.url = url or _build_sqlalchemy_url()
-        self.engine: Engine = create_engine(self.url, pool_pre_ping=True, future=True)
+        # self.url = url or _build_sqlalchemy_url()
+        # self.engine: Engine = create_engine(self.url, pool_pre_ping=True, future=True)
+        self.url = "duckdb://"
+        self.engine: Optional[Engine] = None
         self.max_retries = max(1, max_retries)
         self.retry_interval = max(0.0, retry_interval)
 
-        fallback_enabled = (
-            _env_flag("ENABLE_DUCKDB_FALLBACK", True)
-            if enable_duckdb_fallback is None
-            else enable_duckdb_fallback
-        )
+        # fallback_enabled = (
+        #     _env_flag("ENABLE_DUCKDB_FALLBACK", True)
+        #     if enable_duckdb_fallback is None
+        #     else enable_duckdb_fallback
+        # )
+        fallback_enabled = True
         fallback_path = duckdb_path or os.getenv(
             "DUCKDB_FALLBACK_PATH", os.path.join("data", "postgres_mirror.duckdb")
         )
@@ -610,6 +633,16 @@ class DBManager:
                     mirror.maybe_sync_from_sql_dump()
             else:
                 logger.warning("DuckDB fallback requested but dependencies are unavailable.")
+
+        if self._duckdb_mirror is None:
+            raise RuntimeError(
+                "DuckDB fallback is required while PostgreSQL support is disabled."
+            )
+
+        if not self._duckdb_mirror.is_ready():
+            self._duckdb_mirror.ensure_from_sql_dump()
+
+        self.url = f"duckdb:///{self._duckdb_mirror.path}"
 
         logger.debug(
             "DBManager initialised with url=%s (retries=%d, interval=%.2fs, duckdb_fallback=%s)",
@@ -676,28 +709,15 @@ class DBManager:
 
         logger.debug("Running query: %s | params=%s", sql, params)
 
-        def _query() -> pd.DataFrame:
-            with self.engine.connect() as conn:
-                return pd.read_sql(text(sql), conn, params=params)
+        if self._duckdb_mirror is None:
+            raise RuntimeError("DuckDB backend is not configured")
 
-        try:
-            result = self._run_with_retries(_query, "query")
-        except OperationalError as exc:
-            if self._duckdb_mirror and self._is_transient_operational_error(exc):
-                if self._duckdb_mirror.ensure_from_sql_dump():
-                    logger.warning(
-                        "Primary database query failed (%s); using DuckDB fallback.",
-                        exc,
-                    )
-                    try:
-                        return self._duckdb_mirror.query_df(sql, params)
-                    except Exception as fallback_exc:
-                        logger.error("DuckDB fallback query failed: %s", fallback_exc)
-                        raise exc
-            raise
-        else:
-            self._maybe_sync_duckdb()
-            return result
+        if not self._duckdb_mirror.is_ready():
+            self._duckdb_mirror.ensure_from_sql_dump()
+
+        result = self._duckdb_mirror.query_df(sql, params)
+        # self._maybe_sync_duckdb()
+        return result
 
     def vector_similarity(
         self, query_vector: Sequence[float], *, limit: int = 5
@@ -706,45 +726,29 @@ class DBManager:
 
         payload = list(query_vector)
 
-        sql = """
-            SELECT
-                COALESCE(NULLIF(TRIM(p.consumer_product_name), ''), TRIM(p.product_name)) AS product_name,
-                COALESCE(NULLIF(TRIM(b.consumer_brand_name), ''), TRIM(b.brand_name)) AS brand_name
-            FROM vip_products AS p
-            LEFT JOIN vip_brands AS b ON p.vip_brand_id = b.vip_brand_id
-            ORDER BY p.embedding <-> :vector
-            LIMIT :limit
-        """
+        if self._duckdb_mirror is None:
+            raise RuntimeError("DuckDB backend is not configured")
 
-        def _query() -> pd.DataFrame:
-            with self.engine.connect() as conn:
-                return pd.read_sql(text(sql), conn, params={"vector": payload, "limit": limit})
+        if not self._duckdb_mirror.is_ready():
+            self._duckdb_mirror.ensure_from_sql_dump()
 
-        try:
-            result = self._run_with_retries(_query, "vector search")
-        except OperationalError as exc:
-            if self._duckdb_mirror and self._is_transient_operational_error(exc):
-                if self._duckdb_mirror.ensure_from_sql_dump():
-                    logger.warning(
-                        "Primary vector search failed (%s); using DuckDB fallback.",
-                        exc,
-                    )
-                    return self._duckdb_mirror.vector_similarity(payload, limit=limit)
-            raise
-        else:
-            self._maybe_sync_duckdb()
-            return result
+        result = self._duckdb_mirror.vector_similarity(payload, limit=limit)
+        # self._maybe_sync_duckdb()
+        return result
 
     def execute(self, sql: str, params: Optional[Mapping[str, Any]] = None) -> None:
         """Execute a non-returning statement (INSERT/UPDATE/DDL)."""
 
         logger.debug("Executing statement: %s | params=%s", sql, params)
 
-        def _execute() -> None:
-            with self.engine.begin() as conn:
-                conn.execute(text(sql), params or {})
+        if self._duckdb_mirror is None:
+            raise RuntimeError("DuckDB backend is not configured")
 
-        self._run_with_retries(_execute, "statement")
+        if not self._duckdb_mirror.is_ready():
+            self._duckdb_mirror.ensure_from_sql_dump()
+
+        self._duckdb_mirror.execute(sql, params)
+        # self._maybe_sync_duckdb()
 
     def sync_duckdb_backup(self) -> bool:
         """Manually trigger a DuckDB mirror sync."""
@@ -755,14 +759,15 @@ class DBManager:
         return self._duckdb_mirror.sync_from_sql_dump(force=True)
 
     def close(self) -> None:
-        try:
-            self.engine.dispose()
-            logger.debug("Database engine disposed")
-        except Exception as exc:  # pragma: no cover - best effort cleanup
-            logger.exception("Error disposing engine: %s", exc)
-        finally:
-            if self._duckdb_mirror is not None:
-                self._duckdb_mirror.close()
+        # if self.engine is not None:
+        #     try:
+        #         self.engine.dispose()
+        #         logger.debug("Database engine disposed")
+        #     except Exception as exc:  # pragma: no cover - best effort cleanup
+        #         logger.exception("Error disposing engine: %s", exc)
+        if self._duckdb_mirror is not None:
+            self._duckdb_mirror.close()
+            logger.debug("DuckDB mirror closed")
 
 
 # Global helper similar to the original project

--- a/src/llm/manager.py
+++ b/src/llm/manager.py
@@ -1,19 +1,62 @@
 """Central manager for large language models.
 
 This class hides the details of interacting with a specific provider
-(Amazon Bedrock in this project) and exposes a simple generate API.  At
+(Amazon Bedrock in this project) and exposes a simple generate API.  At
 initialisation time it builds the appropriate wrapper based on a config
 dictionary.
 """
 from __future__ import annotations
 
-from typing import List, Tuple, Dict, Any, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import logging
-
-from .bedrock import BedrockLLM
+import os
 
 logger = logging.getLogger(__name__)
+
+try:  # Optional Bedrock dependency – unavailable when the LLM is disabled
+    from .bedrock import BedrockLLM  # type: ignore
+except Exception as exc:  # pragma: no cover - optional dependency guard
+    BedrockLLM = None  # type: ignore
+    _BEDROCK_IMPORT_ERROR: Optional[Exception] = exc
+else:  # pragma: no cover - executed only when dependency is present
+    _BEDROCK_IMPORT_ERROR = None
+
+try:  # Embeddings are also optional in DuckDB-only mode
+    from .embeddings import EmbeddingManager as _EmbeddingManager  # type: ignore
+except Exception as exc:  # pragma: no cover - optional dependency guard
+    _EmbeddingManager = None  # type: ignore
+    _EMBEDDINGS_IMPORT_ERROR: Optional[Exception] = exc
+else:  # pragma: no cover
+    _EMBEDDINGS_IMPORT_ERROR = None
+
+
+def _env_flag(name: str, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    value = value.strip().lower()
+    if value in {"1", "true", "yes", "on"}:
+        return True
+    if value in {"0", "false", "no", "off"}:
+        return False
+    return default
+
+
+class _DisabledLLM:
+    """Placeholder client used when Bedrock access is disabled."""
+
+    def generate(
+        self,
+        user_request: str,
+        chat_history: List[Tuple[str, str]],
+        context: str | None = None,
+    ) -> str:
+        raise RuntimeError("LLM access is disabled in DuckDB-only mode")
+
+    def __repr__(self) -> str:  # pragma: no cover - representational helper
+        return "<DisabledLLM>"
+
 
 class LLMManager:
     """Entry point for working with LLMs.
@@ -25,17 +68,28 @@ class LLMManager:
         ``llm`` section with model parameters and a ``bedrock`` section with
         AWS region information.
     llm : object
-        Low‑level client implementing a ``generate(user_request, chat_history)``
+        Low-level client implementing a ``generate(user_request, chat_history)``
         method.  Consumers should rarely instantiate this class directly –
         instead call :meth:`from_config`.
     """
 
-    def __init__(self, config: Dict[str, Any], llm: Any):
+    def __init__(
+        self,
+        config: Dict[str, Any],
+        llm: Any,
+        *,
+        embedding_manager: Optional[Any] = None,
+    ) -> None:
         self.config = config
-        self.llm = llm
+        self.llm = llm or _DisabledLLM()
+        self._embedding_manager = embedding_manager
+        self._enabled = not isinstance(self.llm, _DisabledLLM)
 
-        logger.debug("LLMManager initialised with config: %s", config)
-
+        logger.debug(
+            "LLMManager initialised with config: %s | enabled=%s",
+            config,
+            self._enabled,
+        )
 
     @classmethod
     def from_config(cls, config: Dict[str, Any]) -> "LLMManager":
@@ -45,8 +99,41 @@ class LLMManager:
 
         logger.info("Creating LLMManager from config")
 
-        llm = BedrockLLM(config)
-        return cls(config, llm)
+        enable_llm = _env_flag("ENABLE_LLM", False)
+        if not enable_llm or BedrockLLM is None:
+            if not enable_llm:
+                logger.info("ENABLE_LLM not set – returning disabled LLM manager")
+            elif _BEDROCK_IMPORT_ERROR is not None:
+                logger.warning(
+                    "Bedrock client unavailable (%s); running with disabled LLM",
+                    _BEDROCK_IMPORT_ERROR,
+                )
+            return cls(config, _DisabledLLM())
+
+        llm = BedrockLLM(config)  # type: ignore[misc]
+        embedding_manager: Optional[Any] = None
+        if _EmbeddingManager is not None:
+            embedding_manager = _EmbeddingManager()
+        elif _EMBEDDINGS_IMPORT_ERROR is not None:
+            logger.warning(
+                "Embedding manager unavailable (%s); vector features disabled",
+                _EMBEDDINGS_IMPORT_ERROR,
+            )
+        return cls(config, llm, embedding_manager=embedding_manager)
+
+    def is_enabled(self) -> bool:
+        """Return ``True`` when a real LLM backend is configured."""
+
+        return self._enabled
+
+    def get_embedding(self):
+        """Return the embedding helper if available."""
+
+        if not self._enabled or self._embedding_manager is None:
+            raise RuntimeError(
+                "Embedding model is unavailable because the LLM is disabled"
+            )
+        return self._embedding_manager
 
     def generate(
         self,
@@ -55,20 +142,11 @@ class LLMManager:
         *,
         context: str | None = None,
     ) -> str:
-        """Generate a response from the underlying LLM.
-
-        Parameters
-        ----------
-        user_request : str
-            The raw query from the user.
-        chat_history : List of (role, text) tuples
-            Past conversation history in alternating roles.  If omitted an
-            empty history is assumed.
-        """
+        """Generate a response from the underlying LLM."""
 
         logger.info("Generating response for request: %s", user_request)
+        if not self._enabled:
+            raise RuntimeError("LLM access is disabled")
         response = self.llm.generate(user_request, chat_history or [], context=context)
         logger.debug("LLMManager received response: %s", response)
         return response
-
-

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -45,6 +45,10 @@ if "agent_manager" not in st.session_state:
     llm_manager = LLMManager.from_config(llm_config)
     agent_manager = AgentManager(llm_manager)
     st.session_state["agent_manager"] = agent_manager
+    if not llm_manager.is_enabled():
+        st.sidebar.warning(
+            "Language model features are disabled; the assistant will answer using the DuckDB inventory only."
+        )
 
 # Get user input
 user_input = st.chat_input("Your message:")

--- a/tests/test_db_manager.py
+++ b/tests/test_db_manager.py
@@ -1,11 +1,8 @@
 import os
 import sys
-from dataclasses import dataclass
 from textwrap import dedent
 
-import pandas as pd
 import pytest
-from sqlalchemy.exc import OperationalError
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -13,95 +10,21 @@ from src.database.db_manager import DBManager
 
 
 def test_connects_using_db_password(monkeypatch):
-    """DBManager should honour DB_PASSWORD environment variable."""
+    """Placeholder: PostgreSQL connection logic disabled during DuckDB-only testing."""
 
-    # Ensure compatibility variable is absent and DATABASE_URL not set
-    monkeypatch.delenv("DB_PASS", raising=False)
-    monkeypatch.delenv("DATABASE_URL", raising=False)
-    monkeypatch.setenv("DB_PASSWORD", "secret")
-
-    mgr = DBManager(enable_duckdb_fallback=False)
-    try:
-        assert mgr.engine.url.password == "secret"
-    finally:
-        mgr.close()
-
-
-@dataclass
-class _DummyConnection:
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc, tb):
-        return False
+    pytest.skip("PostgreSQL connection handling is disabled while using DuckDB only")
 
 
 def test_query_df_retries_on_connection_refused(monkeypatch):
-    mgr = DBManager(
-        "postgresql://app:pw@localhost:5432/warehouse",
-        max_retries=3,
-        retry_interval=0,
-        enable_duckdb_fallback=False,
-    )
+    """Placeholder for transient PostgreSQL retry behaviour."""
 
-    attempts = {"count": 0}
-
-    def flaky_connect():
-        attempts["count"] += 1
-        if attempts["count"] < 3:
-            raise OperationalError(
-                'connection to server at "localhost" (127.0.0.1), port 5432 failed: Connection refused',
-                None,
-                None,
-            )
-        return _DummyConnection()
-
-    monkeypatch.setattr(mgr.engine, "connect", flaky_connect)
-
-    results = {"called": 0}
-
-    def fake_read_sql(query, conn, params=None):
-        results["called"] += 1
-        return pd.DataFrame(
-            {"store": ["A"], "product_name": ["Widget"], "brand_name": ["Brand"]}
-        )
-
-    monkeypatch.setattr(pd, "read_sql", fake_read_sql)
-
-    try:
-        df = mgr.query_df(
-            "SELECT store, product_name, brand_name FROM app_inventory LIMIT 5",
-            params=None,
-        )
-    finally:
-        mgr.close()
-
-    assert attempts["count"] == 3
-    assert results["called"] == 1
-    assert not df.empty
+    pytest.skip("Transient PostgreSQL retry logic is disabled while using DuckDB only")
 
 
 def test_query_df_does_not_retry_non_transient_error(monkeypatch):
-    mgr = DBManager(
-        "postgresql://app:pw@localhost:5432/warehouse",
-        max_retries=3,
-        retry_interval=0,
-        enable_duckdb_fallback=False,
-    )
+    """Placeholder for non-transient PostgreSQL error handling."""
 
-    attempts = {"count": 0}
-
-    def failing_connect():
-        attempts["count"] += 1
-        raise OperationalError("syntax error at or near \"SELECT\"", None, None)
-
-    monkeypatch.setattr(mgr.engine, "connect", failing_connect)
-
-    with pytest.raises(OperationalError):
-        mgr.query_df("SELECT * FROM bad_table", params=None)
-
-    mgr.close()
-    assert attempts["count"] == 1
+    pytest.skip("PostgreSQL retry behaviour tests are disabled in DuckDB-only mode")
 
 
 def _write_basic_inventory_dump(path):
@@ -154,13 +77,12 @@ def _write_vector_dump(path):
     )
 
 
-def test_query_df_uses_duckdb_fallback(monkeypatch, tmp_path):
+def test_query_df_uses_duckdb_fallback(tmp_path):
     duckdb_path = tmp_path / "mirror.duckdb"
     sql_dump = tmp_path / "dump.sql"
     _write_basic_inventory_dump(sql_dump)
 
     mgr = DBManager(
-        "postgresql://app:pw@localhost:5432/warehouse",
         max_retries=1,
         retry_interval=0,
         enable_duckdb_fallback=True,
@@ -169,15 +91,6 @@ def test_query_df_uses_duckdb_fallback(monkeypatch, tmp_path):
         duckdb_auto_sync=False,
         duckdb_sql_dump_path=str(sql_dump),
     )
-
-    def failing_connect():
-        raise OperationalError(
-            'connection to server at "localhost" (127.0.0.1), port 5432 failed: Connection refused',
-            None,
-            None,
-        )
-
-    monkeypatch.setattr(mgr.engine, "connect", failing_connect)
 
     try:
         df = mgr.query_df(
@@ -191,13 +104,12 @@ def test_query_df_uses_duckdb_fallback(monkeypatch, tmp_path):
     assert df.iloc[0]["product_name"] == "Widget"
 
 
-def test_vector_similarity_uses_duckdb_fallback(monkeypatch, tmp_path):
+def test_vector_similarity_uses_duckdb_fallback(tmp_path):
     duckdb_path = tmp_path / "mirror.duckdb"
     sql_dump = tmp_path / "dump.sql"
     _write_vector_dump(sql_dump)
 
     mgr = DBManager(
-        "postgresql://app:pw@localhost:5432/warehouse",
         max_retries=1,
         retry_interval=0,
         enable_duckdb_fallback=True,
@@ -207,21 +119,40 @@ def test_vector_similarity_uses_duckdb_fallback(monkeypatch, tmp_path):
         duckdb_sql_dump_path=str(sql_dump),
     )
 
-    def failing_connect():
-        raise OperationalError(
-            'connection to server at "localhost" (127.0.0.1), port 5432 failed: Connection refused',
-            None,
-            None,
-        )
-
-    monkeypatch.setattr(mgr.engine, "connect", failing_connect)
-
     try:
-        df = mgr.vector_similarity([0.0, 1.0], limit=5)
+        df = mgr.vector_similarity([0.0, 1.0], limit=2)
     finally:
         mgr.close()
 
     assert not df.empty
+    assert "product_name" in df.columns
     assert df.iloc[0]["product_name"] == "Consumer Gin"
     assert df.iloc[0]["brand_name"] == "Brand Co"
 
+
+def test_execute_updates_duckdb(tmp_path):
+    duckdb_path = tmp_path / "mirror.duckdb"
+    sql_dump = tmp_path / "dump.sql"
+    _write_vector_dump(sql_dump)
+
+    mgr = DBManager(
+        enable_duckdb_fallback=True,
+        duckdb_path=str(duckdb_path),
+        duckdb_tables=["vip_products", "vip_brands"],
+        duckdb_auto_sync=False,
+        duckdb_sql_dump_path=str(sql_dump),
+    )
+
+    try:
+        mgr.execute(
+            "UPDATE vip_products SET product_name = :name WHERE vip_product_id = :pid",
+            {"name": "Updated Gin", "pid": 1},
+        )
+        df = mgr.query_df(
+            "SELECT product_name FROM vip_products WHERE vip_product_id = :pid",
+            {"pid": 1},
+        )
+    finally:
+        mgr.close()
+
+    assert df.iloc[0]["product_name"] == "Updated Gin"

--- a/tests/test_init_db.py
+++ b/tests/test_init_db.py
@@ -12,8 +12,10 @@ def reset_db_manager():
 
 
 def test_main_exits_when_table_missing(tmp_path, monkeypatch):
-    db_file = tmp_path / "test.db"
-    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_file}")
+    duckdb_file = tmp_path / "test.duckdb"
+    monkeypatch.setenv("DUCKDB_FALLBACK_PATH", str(duckdb_file))
+    monkeypatch.delenv("DUCKDB_SQL_DUMP", raising=False)
+    monkeypatch.delenv("SQL_FILE", raising=False)
     with pytest.raises(SystemExit):
         init_db.main()
 

--- a/tests/test_llm_manager.py
+++ b/tests/test_llm_manager.py
@@ -1,6 +1,8 @@
 """Tests for the LLMManager and context handling."""
 from __future__ import annotations
 
+import pytest
+
 from src.llm.manager import LLMManager
 
 
@@ -18,3 +20,11 @@ def test_generate_with_context():
     manager = LLMManager({}, llm)
     manager.generate("hi", [("user", "hi")], context="ctx")
     assert llm.called_with == ("hi", [("user", "hi")], "ctx")
+
+
+def test_from_config_disabled_when_flag_missing(monkeypatch):
+    monkeypatch.delenv("ENABLE_LLM", raising=False)
+    manager = LLMManager.from_config({})
+    assert not manager.is_enabled()
+    with pytest.raises(RuntimeError):
+        manager.generate("hello", [])


### PR DESCRIPTION
## Summary
- rework `run_all.sh` to skip Postgres orchestration, hydrate a DuckDB database from the sanitized dump, regenerate `app_inventory`, and export schema/verification data while gating Bedrock env checks behind `ENABLE_LLM`. 
- add an `ENABLE_LLM`-aware `_DisabledLLM` path so the manager, agents, embeddings script, and UI all short-circuit gracefully when Bedrock is disabled and surface an explicit warning.
- pivot the database config to DuckDB defaults and extend the LLM tests to cover the disabled code path.

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68c9907c97c083228a15d78a0954ee3b