### PR TITLE
Fix ProductLookupAgent smoke test to pass chat history

### DIFF
--- a/scripts/test_db_and_agent.sh
+++ b/scripts/test_db_and_agent.sh
@@ -107,8 +107,11 @@ tests = [
 
 for q in tests:
     print("\n[py] Q:", q)
+    chat_history = [("user", q)]
     try:
-        ans = agent.handle(q)
+        score = agent.score_request(q, chat_history)
+        print(f"[py] score_request -> {score:.2f}")
+        ans = agent.handle(q, chat_history)
         print(textwrap.shorten("[py] A: " + (ans or ""), width=500))
     except Exception as e:
         print("[py][x] Error:", repr(e))


### PR DESCRIPTION
## Summary
- update the ProductLookupAgent smoke test script to pass a chat history and log the scoring step

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cc3905d1e4832298ec30708095538e