### PR TITLE
Improve specialist synthesis and enforce Bedrock region

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ explicit configuration for LLMs, data sources and runtime environment.
    pip install -r requirements.txt
    ```
 
-3. **Copy the `.env.example` to `.env` and edit it** – set your AWS region, database credentials, S3 bucket and key.
-   For the LLM configuration set `BEDROCK_MODEL_ID=amazon.nova-pro-v1:0`.
+3. **Copy the `.env.example` to `.env` and edit it** – set your database credentials, S3 bucket and key.
+   The application now enforces the `us-east-1` AWS region for all Bedrock calls, so ensure your credentials have access in that
+   region. For the LLM configuration set `BEDROCK_MODEL_ID=amazon.nova-pro-v1:0`.
 
 4. **Initialise the database**
 

--- a/src/agents/response_evaluator.py
+++ b/src/agents/response_evaluator.py
@@ -32,15 +32,27 @@ class ResponseEvaluator:
     # Patterns that suggest the agent could not handle the request
     FAILURE_PATTERNS = (
         r"i'm sorry",
+        r"i am sorry",
         r"couldn't",
         r"cannot",
+        r"can't",
         r"no results found",
         r"no products found",
         r"language model is unavailable",
+        r"i don't know",
+        r"i do not know",
+        r"not sure",
+        r"unable to",
+        r"no information",
+        r"please try again",
     )
 
     def evaluate(self, user_request: str, response: str) -> float:
         """Return a score in [0, 1] for the supplied response."""
+        if not response or not response.strip():
+            logger.debug("ResponseEvaluator: empty response detected")
+            return 0.0
+
         text = response.lower()
         if any(re.search(pat, text) for pat in self.FAILURE_PATTERNS):
             logger.debug(

--- a/src/config/llm_config.yaml
+++ b/src/config/llm_config.yaml
@@ -6,4 +6,4 @@ llm:
   max_tokens: ${LLM_MAX_TOKENS}
 bedrock:
   # AWS region for Bedrock runtime
-  region_name: ${AWS_REGION}
+  region_name: us-east-1

--- a/src/llm/bedrock.py
+++ b/src/llm/bedrock.py
@@ -37,9 +37,17 @@ class BedrockLLM:
         if not model_id or "$" in model_id:
             model_id = "amazon.nova-pro-v1:0"
 
-        region = bed_conf.get("region_name")
-        if not region or "$" in region:
-            region = os.getenv("AWS_REGION", "us-east-1")
+        configured_region = bed_conf.get("region_name")
+        env_region = os.getenv("AWS_REGION")
+        default_region = "us-east-1"
+        region = configured_region or env_region or default_region
+        if region != default_region:
+            logger.warning(
+                "BedrockLLM overriding region %s with required region %s",
+                region,
+                default_region,
+            )
+            region = default_region
 
         def _safe_cast(value: Any, cast, default):
             try:

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -62,7 +62,7 @@ def test_general_agent_receives_specialist_context():
     assert llm.last_context is not None
     assert "First specialist answer" in llm.last_context
     assert "Second specialist answer" in llm.last_context
-    assert "specialist agent outputs" in llm.last_context.lower()
+    assert "validated findings" in llm.last_context.lower()
     trace = manager.get_last_trace()
     assert trace is not None
     assert trace["user_request"] == "request"


### PR DESCRIPTION
## Summary
- refine the agent manager context so the general responder only sees validated findings instead of every raw agent transcript
- harden response evaluation and SQL query authoring by expanding failure heuristics, smarter routing, and better LLM prompting (including fuzzy name matching guidance)
- force Amazon Bedrock usage to the us-east-1 region and document the requirement

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd856eb498832292e256741c340195