### PR TITLE
Fix init_db imports when executed directly

### DIFF
--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -16,6 +16,13 @@ ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
+# Also ensure the repository root is importable so ``scripts`` becomes a
+# namespace package when this module is executed directly (``python
+# scripts/init_db.py``).  Without this adjustment, the absolute import of
+# ``scripts.index_embeddings`` below fails because Python's import machinery
+# only adds the *script* directory to ``sys.path`` by default, not its parent.
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 from config.logging_config import setup_logging  # noqa: E402
 from database.db_manager import get_db  # noqa: E402  (import after path tweak)


### PR DESCRIPTION
## Summary
- ensure scripts/init_db.py adds the repository root to sys.path when executed directly so absolute imports of other scripts work
- document the rationale for the path tweak to avoid ModuleNotFoundError when running python scripts/init_db.py

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd8c5a89548322bef97c1055c6c0ed