### PR TITLE
Fix schema.json path resolution

### DIFF
--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -16,6 +16,13 @@ ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
+# Also ensure the repository root is importable so ``scripts`` becomes a
+# namespace package when this module is executed directly (``python
+# scripts/init_db.py``).  Without this adjustment, the absolute import of
+# ``scripts.index_embeddings`` below fails because Python's import machinery
+# only adds the *script* directory to ``sys.path`` by default, not its parent.
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 from config.logging_config import setup_logging  # noqa: E402
 from database.db_manager import get_db  # noqa: E402  (import after path tweak)

--- a/src/agents/sql_query_agent.py
+++ b/src/agents/sql_query_agent.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 from typing import List, Tuple
 import boto3
 import json
@@ -7,6 +8,9 @@ from src.database.db_manager import get_db
 from src.llm.manager import LLMManager
 
 logger = logging.getLogger(__name__)
+
+
+SCHEMA_PATH = Path(__file__).resolve().parents[1] / "database" / "schema.json"
 
 
 def _format_schema_for_prompt(tables: dict[str, list[str]]) -> str:
@@ -206,7 +210,7 @@ class SqlQueryAgent(AgentBase):
         # Load database schema from JSON if available, otherwise introspect
         schema_str = ""
         try:
-            with open("src/database/schema.json", "r") as f:
+            with SCHEMA_PATH.open("r", encoding="utf-8") as f:
                 schema_json = json.load(f)
             tables = {}
             # Determine format of schema JSON

--- a/tests/test_schema_json.py
+++ b/tests/test_schema_json.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 
 def test_schema_json_is_valid_and_includes_app_inventory():
-    path = Path("src/database/schema.json")
+    path = Path(__file__).resolve().parents[1] / "src" / "database" / "schema.json"
     data = json.loads(path.read_text())
     assert "app_inventory" in data
     assert isinstance(data["app_inventory"], list)


### PR DESCRIPTION
## Summary
- resolve the SQL query agent's schema.json lookup relative to the src package so it works regardless of the working directory
- update the schema.json test to read the file via an absolute path derived from the test file location

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd8c5a89548322bef97c1055c6c0ed